### PR TITLE
require new tf2onnx

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ requirements_pytorch = [
 
 requirements_jax = [
     "tensorflow",
-    "tf2onnx",
+    "tf2onnx>=1.16.0",
     "jax",
     "equinox",
     "numpy<2",


### PR DESCRIPTION
Some deeper dependency is causing tf2onnx to default to version 1.8, which has some numpy deprecated lines. Not seeing any immediate errors in just fast-forwarding tf2onnx