### PR TITLE
bump version new release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ resolver = "2"
 
 [workspace.package]
 
-version = "0.5.6"
+version = "0.6.0"
 authors = ["Wesley Maa <wesley@kscale.dev>", "Benjamin Bolte <ben@kscale.dev>"]
 edition = "2021"
 description = "K-Scale Inference Library"


### PR DESCRIPTION
the previous pr #46 was breaking so i think we should go to v0.6.0. also need new pip install version to fix depending packages

will also put in pr to fix kinfer-sim